### PR TITLE
Voeg push notificaties toe voor aankomende diensten

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -63,6 +63,8 @@ import {
   tvSharp,
   flaskOutline,
   flaskSharp,
+  settingsOutline,
+  settingsSharp,
 } from "ionicons/icons";
 import router from "./router";
 
@@ -111,7 +113,12 @@ export default {
           iosIcon: flaskOutline,
           mdIcon: flaskSharp,
         },
-
+        {
+          title: "Instellingen",
+          url: "/Settings",
+          iosIcon: settingsOutline,
+          mdIcon: settingsSharp,
+        },
       ],
     };
   },

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,12 +24,16 @@ import '@ionic/vue/css/display.css';
 import './theme/variables.css';
 
 import './registerServiceWorker';
+import { initializeNotifications } from './services/NotificationService';
 
 const app = createApp(App)
   .use(IonicVue)
   .use(router);
-  
+
 router.isReady().then(() => {
   app.mount('#app');
+
+  // Initialize notification system
+  initializeNotifications();
 });
 

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -29,6 +29,10 @@ const routes: Array<RouteRecordRaw> = [
   {
     path: '/Agenda',
     component: () => import ('../views/Agenda.vue')
+  },
+  {
+    path: '/Settings',
+    component: () => import ('../views/Settings.vue')
   }
 ]
 

--- a/src/services/NotificationService.ts
+++ b/src/services/NotificationService.ts
@@ -1,0 +1,153 @@
+import Service from './Service';
+
+export interface DienstNotification {
+  userName: string;
+  startDienst: string;
+  hasShift: boolean;
+}
+
+/**
+ * Check if user has a shift today
+ * @param userName The name of the user to check
+ * @returns Promise with notification info
+ */
+export async function checkUserShiftToday(userName: string): Promise<DienstNotification> {
+  if (!userName) {
+    return { userName: '', startDienst: '', hasShift: false };
+  }
+
+  try {
+    const diensten = await Service.getDiensten();
+    const today = new Date();
+    const todayStr = today.toISOString().split('T')[0]; // Format: 2024-10-20
+
+    // Find shifts for today that match the user's name
+    const todayShift = diensten.find((dienst: any) => {
+      // Extract date from "2024-10-20 start 14:00" format
+      const dienstDate = dienst.StartDienst?.split(' start ')[0];
+
+      const zaalwacht = dienst.Zaalwacht || '';
+      const zaalwachtLower = zaalwacht.toLowerCase();
+      const userNameLower = userName.toLowerCase();
+
+      // Check if date matches today and name matches user (case insensitive)
+      // BUT: skip if there's a '(' before the name (indicating a traded shift)
+      if (dienstDate === todayStr && zaalwachtLower.includes(userNameLower)) {
+        // Find the position of the username in the Zaalwacht string
+        const namePosition = zaalwachtLower.indexOf(userNameLower);
+
+        // Check if there's a '(' before the name (accounting for possible whitespace)
+        if (namePosition > 0) {
+          const beforeName = zaalwacht.substring(0, namePosition).trim();
+          // If the character right before the name (after trimming) is '(', skip this shift
+          if (beforeName.endsWith('(')) {
+            return false;
+          }
+        }
+
+        return true;
+      }
+
+      return false;
+    });
+
+    if (todayShift) {
+      return {
+        userName,
+        startDienst: todayShift.StartDienst,
+        hasShift: true
+      };
+    }
+
+    return { userName, startDienst: '', hasShift: false };
+  } catch (error) {
+    console.error('Error checking shift:', error);
+    return { userName, startDienst: '', hasShift: false };
+  }
+}
+
+/**
+ * Send a notification to the user about their shift
+ * @param notification The notification info
+ */
+export function sendShiftNotification(notification: DienstNotification): void {
+  if (!notification.hasShift || !notification.startDienst) {
+    return;
+  }
+
+  // Extract time from "2024-10-20 start 14:00" format
+  const timePart = notification.startDienst.split(' start ')[1] || '';
+
+  if (Notification.permission === 'granted') {
+    new Notification('Dienst Vandaag! 🎭', {
+      body: `Hoi ${notification.userName}! Je hebt vandaag dienst bij de Verkadefabriek om ${timePart} uur.`,
+      icon: '/img/icons/android-chrome-192x192.png',
+      badge: '/img/icons/android-chrome-192x192.png',
+      tag: 'dienst-reminder',
+      requireInteraction: true, // Keeps notification visible until user interacts
+    });
+  }
+}
+
+/**
+ * Schedule daily notification check at 10:00
+ * This function sets up a daily check and should be called when notifications are enabled
+ */
+export function scheduleDailyNotifications(): void {
+  const now = new Date();
+  const target = new Date();
+  target.setHours(10, 0, 0, 0); // 10:00 AM
+
+  // If it's already past 10:00 today, schedule for tomorrow
+  if (now > target) {
+    target.setDate(target.getDate() + 1);
+  }
+
+  const timeUntilCheck = target.getTime() - now.getTime();
+
+  console.log(`Next notification check scheduled in ${Math.round(timeUntilCheck / 1000 / 60)} minutes`);
+
+  // Schedule the first check
+  setTimeout(() => {
+    performDailyCheck();
+    // Then schedule daily checks (every 24 hours)
+    setInterval(performDailyCheck, 24 * 60 * 60 * 1000);
+  }, timeUntilCheck);
+}
+
+/**
+ * Perform the daily check for shifts and send notification if needed
+ */
+async function performDailyCheck(): Promise<void> {
+  const notificationsEnabled = localStorage.getItem('zaalwacht_notificationsEnabled') === 'true';
+  const userName = localStorage.getItem('zaalwacht_userName');
+
+  if (!notificationsEnabled || !userName) {
+    console.log('Daily check skipped: notifications disabled or no user name');
+    return;
+  }
+
+  console.log(`Performing daily shift check for ${userName} at 10:00`);
+
+  const notification = await checkUserShiftToday(userName);
+
+  if (notification.hasShift) {
+    console.log(`Sending notification: ${userName} has a shift today`);
+    sendShiftNotification(notification);
+  } else {
+    console.log(`No shift today for ${userName}`);
+  }
+}
+
+/**
+ * Initialize notifications on app startup
+ * This should be called in main.ts or App.vue
+ */
+export function initializeNotifications(): void {
+  const notificationsEnabled = localStorage.getItem('zaalwacht_notificationsEnabled') === 'true';
+
+  if (notificationsEnabled && Notification.permission === 'granted') {
+    scheduleDailyNotifications();
+    console.log('Notification system initialized');
+  }
+}

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -1,0 +1,251 @@
+<template>
+  <ion-page>
+    <ion-header :translucent="true">
+      <ion-toolbar>
+        <ion-buttons>
+          <ion-menu-button color="primary"></ion-menu-button>
+        </ion-buttons>
+        <ion-title>Instellingen</ion-title>
+      </ion-toolbar>
+    </ion-header>
+
+    <ion-content :fullscreen="true">
+      <ion-header collapse="condense">
+        <ion-toolbar>
+          <ion-title size="large">Instellingen</ion-title>
+        </ion-toolbar>
+      </ion-header>
+
+      <div id="container">
+        <ion-list>
+          <ion-list-header>
+            <ion-label>Dienst Notificaties</ion-label>
+          </ion-list-header>
+
+          <ion-item>
+            <ion-label position="stacked">Je naam (zoals in de dienstenlijst)</ion-label>
+            <ion-input
+              v-model="userName"
+              placeholder="Bijv. John Doe"
+              @ionChange="saveUserName"
+            ></ion-input>
+          </ion-item>
+
+          <ion-item>
+            <ion-label>Dagelijkse notificaties (10:00 uur)</ion-label>
+            <ion-toggle
+              v-model="notificationsEnabled"
+              @ionChange="toggleNotifications"
+              :disabled="!userName"
+            ></ion-toggle>
+          </ion-item>
+
+          <ion-item v-if="notificationsEnabled && userName">
+            <ion-label class="ion-text-wrap">
+              <p>
+                <ion-icon :icon="checkmarkCircle" color="success"></ion-icon>
+                Je ontvangt elke ochtend om 10:00 uur een notificatie als je die dag dienst hebt.
+              </p>
+            </ion-label>
+          </ion-item>
+
+          <ion-item v-if="!userName">
+            <ion-label class="ion-text-wrap">
+              <p>
+                <ion-icon :icon="informationCircle" color="warning"></ion-icon>
+                Voer eerst je naam in om notificaties te activeren.
+              </p>
+            </ion-label>
+          </ion-item>
+
+          <ion-item v-if="userName && !notificationsEnabled">
+            <ion-label class="ion-text-wrap">
+              <p>
+                <ion-icon :icon="informationCircle" color="medium"></ion-icon>
+                Notificaties zijn uitgeschakeld.
+              </p>
+            </ion-label>
+          </ion-item>
+
+          <ion-item v-if="notificationPermission === 'denied'">
+            <ion-label class="ion-text-wrap" color="danger">
+              <p>
+                <ion-icon :icon="closeCircle" color="danger"></ion-icon>
+                Browser notificaties zijn geblokkeerd. Sta notificaties toe in je browser instellingen.
+              </p>
+            </ion-label>
+          </ion-item>
+        </ion-list>
+
+        <ion-list v-if="userName">
+          <ion-list-header>
+            <ion-label>Test Notificatie</ion-label>
+          </ion-list-header>
+          <ion-item>
+            <ion-button expand="block" @click="testNotification">
+              Verstuur Test Notificatie
+            </ion-button>
+          </ion-item>
+        </ion-list>
+      </div>
+    </ion-content>
+  </ion-page>
+</template>
+
+<script lang="ts">
+import {
+  IonButtons,
+  IonContent,
+  IonHeader,
+  IonMenuButton,
+  IonPage,
+  IonTitle,
+  IonToolbar,
+  IonList,
+  IonListHeader,
+  IonItem,
+  IonLabel,
+  IonInput,
+  IonToggle,
+  IonButton,
+  IonIcon,
+} from "@ionic/vue";
+import { checkmarkCircle, informationCircle, closeCircle } from "ionicons/icons";
+import { scheduleDailyNotifications, checkUserShiftToday, sendShiftNotification } from "@/services/NotificationService";
+
+export default {
+  name: "Settings",
+  components: {
+    IonButtons,
+    IonContent,
+    IonHeader,
+    IonMenuButton,
+    IonPage,
+    IonTitle,
+    IonToolbar,
+    IonList,
+    IonListHeader,
+    IonItem,
+    IonLabel,
+    IonInput,
+    IonToggle,
+    IonButton,
+    IonIcon,
+  },
+  data() {
+    return {
+      userName: "",
+      notificationsEnabled: false,
+      notificationPermission: "default",
+      checkmarkCircle,
+      informationCircle,
+      closeCircle,
+    };
+  },
+  methods: {
+    saveUserName() {
+      if (this.userName) {
+        localStorage.setItem("zaalwacht_userName", this.userName);
+      } else {
+        localStorage.removeItem("zaalwacht_userName");
+        this.notificationsEnabled = false;
+        localStorage.setItem("zaalwacht_notificationsEnabled", "false");
+      }
+    },
+    async toggleNotifications() {
+      if (this.notificationsEnabled) {
+        // Request permission
+        const permission = await this.requestNotificationPermission();
+        if (permission === "granted") {
+          localStorage.setItem("zaalwacht_notificationsEnabled", "true");
+          this.scheduleNotifications();
+        } else {
+          this.notificationsEnabled = false;
+          localStorage.setItem("zaalwacht_notificationsEnabled", "false");
+          alert("Notificaties zijn geblokkeerd. Sta notificaties toe in je browser instellingen.");
+        }
+      } else {
+        localStorage.setItem("zaalwacht_notificationsEnabled", "false");
+        this.cancelNotifications();
+      }
+    },
+    async requestNotificationPermission() {
+      if (!("Notification" in window)) {
+        alert("Deze browser ondersteunt geen notificaties.");
+        return "denied";
+      }
+
+      const permission = await Notification.requestPermission();
+      this.notificationPermission = permission;
+      return permission;
+    },
+    scheduleNotifications() {
+      // Schedule daily notifications at 10:00
+      scheduleDailyNotifications();
+      console.log("Notificaties geactiveerd voor", this.userName);
+    },
+    cancelNotifications() {
+      console.log("Notificaties gedeactiveerd");
+      // Note: We can't easily cancel setTimeout/setInterval across page reloads
+      // The notification system will check localStorage on each run
+    },
+    async testNotification() {
+      if (Notification.permission === "granted") {
+        // Check if user has a shift today
+        const notification = await checkUserShiftToday(this.userName);
+
+        if (notification.hasShift) {
+          sendShiftNotification(notification);
+        } else {
+          // Send a test notification anyway
+          new Notification("Test Notificatie", {
+            body: `Hoi ${this.userName}! Dit is een test notificatie. Je hebt vandaag geen dienst.`,
+            icon: "/img/icons/android-chrome-192x192.png",
+            badge: "/img/icons/android-chrome-192x192.png",
+            tag: "test-notification",
+          });
+        }
+      } else {
+        this.requestNotificationPermission();
+      }
+    },
+    checkNotificationPermission() {
+      if ("Notification" in window) {
+        this.notificationPermission = Notification.permission;
+      }
+    },
+  },
+  mounted() {
+    // Load saved settings
+    const savedUserName = localStorage.getItem("zaalwacht_userName");
+    const savedNotificationsEnabled = localStorage.getItem("zaalwacht_notificationsEnabled");
+
+    if (savedUserName) {
+      this.userName = savedUserName;
+    }
+
+    if (savedNotificationsEnabled === "true") {
+      this.notificationsEnabled = true;
+    }
+
+    this.checkNotificationPermission();
+  },
+};
+</script>
+
+<style scoped>
+#container {
+  padding: 1rem;
+}
+
+ion-item p {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0.5rem 0;
+}
+
+ion-button {
+  margin: 1rem;
+}
+</style>


### PR DESCRIPTION
- Nieuwe Settings pagina voor notificatie configuratie
- Gebruiker kan eigen naam invoeren (opgeslagen in localStorage)
- Dagelijkse notificaties om 10:00 uur voor diensten van die dag
- Intelligente naam matching met diensten API
- Geruild diensten worden geskipt (geen notificatie als '(' voor naam)
- Browser notification permission handling
- Test notificatie functie
- NotificationService voor scheduling en dienst checks
- Automatische initialisatie bij app start
- Settings toegevoegd aan menu en router

Functionaliteit:
- Gebruiker voert naam in zoals in dienstenlijst
- Zet notificaties aan/uit via toggle
- Elke dag om 10:00 checkt app of gebruiker dienst heeft
- Bij match: notificatie met tijd van dienst
- Bij geruild dienst (naam tussen haakjes): geen notificatie

🤖 Generated with [Claude Code](https://claude.com/claude-code)