### PR TITLE
Fix mobile notification support using Service Worker API

### DIFF
--- a/src/services/NotificationService.ts
+++ b/src/services/NotificationService.ts
@@ -67,10 +67,28 @@ export async function checkUserShiftToday(userName: string): Promise<DienstNotif
 }
 
 /**
+ * Get the service worker registration
+ * @returns Promise with service worker registration or null
+ */
+async function getServiceWorkerRegistration(): Promise<ServiceWorkerRegistration | null> {
+  if ('serviceWorker' in navigator) {
+    try {
+      const registration = await navigator.serviceWorker.ready;
+      return registration;
+    } catch (error) {
+      console.error('Failed to get service worker registration:', error);
+      return null;
+    }
+  }
+  return null;
+}
+
+/**
  * Send a notification to the user about their shift
+ * Uses Service Worker API for mobile compatibility
  * @param notification The notification info
  */
-export function sendShiftNotification(notification: DienstNotification): void {
+export async function sendShiftNotification(notification: DienstNotification): Promise<void> {
   if (!notification.hasShift || !notification.startDienst) {
     return;
   }
@@ -78,14 +96,90 @@ export function sendShiftNotification(notification: DienstNotification): void {
   // Extract time from "2024-10-20 start 14:00" format
   const timePart = notification.startDienst.split(' start ')[1] || '';
 
-  if (Notification.permission === 'granted') {
-    new Notification('Dienst Vandaag! 🎭', {
-      body: `Hoi ${notification.userName}! Je hebt vandaag dienst bij de Verkadefabriek om ${timePart} uur.`,
-      icon: '/img/icons/android-chrome-192x192.png',
-      badge: '/img/icons/android-chrome-192x192.png',
-      tag: 'dienst-reminder',
-      requireInteraction: true, // Keeps notification visible until user interacts
-    });
+  if (Notification.permission !== 'granted') {
+    console.log('Notification permission not granted');
+    return;
+  }
+
+  const notificationOptions: NotificationOptions & { vibrate?: number[] } = {
+    body: `Hoi ${notification.userName}! Je hebt vandaag dienst bij de Verkadefabriek om ${timePart} uur.`,
+    icon: '/img/icons/android-chrome-192x192.png',
+    badge: '/img/icons/android-chrome-192x192.png',
+    tag: 'dienst-reminder',
+    requireInteraction: true,
+    vibrate: [200, 100, 200], // Vibration pattern for mobile
+    data: {
+      dateOfArrival: Date.now(),
+      primaryKey: 1
+    }
+  };
+
+  try {
+    // Try to use Service Worker notification (works on mobile)
+    const registration = await getServiceWorkerRegistration();
+    if (registration) {
+      await registration.showNotification('Dienst Vandaag! 🎭', notificationOptions);
+      console.log('Notification sent via Service Worker');
+    } else {
+      // Fallback to regular notification API (desktop browsers)
+      new Notification('Dienst Vandaag! 🎭', notificationOptions);
+      console.log('Notification sent via Notification API');
+    }
+  } catch (error) {
+    console.error('Failed to send notification:', error);
+    // Try fallback
+    try {
+      new Notification('Dienst Vandaag! 🎭', notificationOptions);
+    } catch (fallbackError) {
+      console.error('Fallback notification also failed:', fallbackError);
+    }
+  }
+}
+
+/**
+ * Send a test notification
+ * @param userName The user's name
+ * @param hasShiftToday Whether the user has a shift today
+ */
+export async function sendTestNotification(userName: string, hasShiftToday: boolean): Promise<void> {
+  if (Notification.permission !== 'granted') {
+    console.log('Notification permission not granted');
+    return;
+  }
+
+  const notificationOptions: NotificationOptions & { vibrate?: number[] } = {
+    body: hasShiftToday
+      ? `Hoi ${userName}! Dit is een test. Je hebt vandaag dienst.`
+      : `Hoi ${userName}! Dit is een test notificatie. Je hebt vandaag geen dienst.`,
+    icon: '/img/icons/android-chrome-192x192.png',
+    badge: '/img/icons/android-chrome-192x192.png',
+    tag: 'test-notification',
+    vibrate: [200, 100, 200],
+    data: {
+      dateOfArrival: Date.now(),
+      primaryKey: 2
+    }
+  };
+
+  try {
+    // Try to use Service Worker notification (works on mobile)
+    const registration = await getServiceWorkerRegistration();
+    if (registration) {
+      await registration.showNotification('Test Notificatie 📱', notificationOptions);
+      console.log('Test notification sent via Service Worker');
+    } else {
+      // Fallback to regular notification API (desktop browsers)
+      new Notification('Test Notificatie 📱', notificationOptions);
+      console.log('Test notification sent via Notification API');
+    }
+  } catch (error) {
+    console.error('Failed to send test notification:', error);
+    // Try fallback
+    try {
+      new Notification('Test Notificatie 📱', notificationOptions);
+    } catch (fallbackError) {
+      console.error('Fallback test notification also failed:', fallbackError);
+    }
   }
 }
 
@@ -133,7 +227,7 @@ async function performDailyCheck(): Promise<void> {
 
   if (notification.hasShift) {
     console.log(`Sending notification: ${userName} has a shift today`);
-    sendShiftNotification(notification);
+    await sendShiftNotification(notification);
   } else {
     console.log(`No shift today for ${userName}`);
   }

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -26,7 +26,7 @@
             <ion-label position="stacked">Je naam (zoals in de dienstenlijst)</ion-label>
             <ion-input
               v-model="userName"
-              placeholder="Bijv. John Doe"
+              placeholder="Bijv. Abu als dat je naam is..."
               @ionChange="saveUserName"
             ></ion-input>
           </ion-item>
@@ -111,7 +111,7 @@ import {
   IonIcon,
 } from "@ionic/vue";
 import { checkmarkCircle, informationCircle, closeCircle } from "ionicons/icons";
-import { scheduleDailyNotifications, checkUserShiftToday, sendShiftNotification } from "@/services/NotificationService";
+import { scheduleDailyNotifications, checkUserShiftToday, sendTestNotification } from "@/services/NotificationService";
 
 export default {
   name: "Settings",
@@ -194,19 +194,10 @@ export default {
         // Check if user has a shift today
         const notification = await checkUserShiftToday(this.userName);
 
-        if (notification.hasShift) {
-          sendShiftNotification(notification);
-        } else {
-          // Send a test notification anyway
-          new Notification("Test Notificatie", {
-            body: `Hoi ${this.userName}! Dit is een test notificatie. Je hebt vandaag geen dienst.`,
-            icon: "/img/icons/android-chrome-192x192.png",
-            badge: "/img/icons/android-chrome-192x192.png",
-            tag: "test-notification",
-          });
-        }
+        // Send test notification using the new mobile-compatible function
+        await sendTestNotification(this.userName, notification.hasShift);
       } else {
-        this.requestNotificationPermission();
+        await this.requestNotificationPermission();
       }
     },
     checkNotificationPermission() {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,7 +8,45 @@ import { VitePWA } from 'vite-plugin-pwa';
 export default defineConfig({
   plugins: [
     vue(),
-    VitePWA({ registerType: 'autoUpdate' })
+    VitePWA({
+      registerType: 'autoUpdate',
+      workbox: {
+        // Add notification-related routes to the service worker cache
+        runtimeCaching: [
+          {
+            urlPattern: /^https:\/\/itstudy\.eu\/zaalwacht\/.*/i,
+            handler: 'NetworkFirst',
+            options: {
+              cacheName: 'api-cache',
+              expiration: {
+                maxEntries: 10,
+                maxAgeSeconds: 60 * 60 // 1 hour
+              }
+            }
+          }
+        ]
+      },
+      manifest: {
+        name: 'Verkadefabriek Zaalwacht',
+        short_name: 'VF Zaalwacht',
+        description: 'PWA voor Verkadefabriek zaalwachten - diensten, agenda en smoelenboek',
+        theme_color: '#3880ff',
+        background_color: '#ffffff',
+        display: 'standalone',
+        icons: [
+          {
+            src: '/img/icons/android-chrome-192x192.png',
+            sizes: '192x192',
+            type: 'image/png'
+          },
+          {
+            src: '/img/icons/android-chrome-512x512.png',
+            sizes: '512x512',
+            type: 'image/png'
+          }
+        ]
+      }
+    })
   ],
   resolve: {
     alias: {


### PR DESCRIPTION
This update enables push notifications on mobile devices (iOS and Android) by using the Service Worker-based notification API instead of the basic Notification constructor.

Changes:
- Update NotificationService to use Service Worker registration.showNotification() for mobile compatibility
- Add sendTestNotification() function with proper mobile support
- Add vibration patterns for mobile devices
- Enhance PWA configuration with proper manifest and caching
- Update Settings view to use new async notification functions

The Service Worker approach is required because:
- iOS Safari doesn't support new Notification() at all
- Mobile browsers require notifications through Service Workers for battery management
- Better integration with mobile OS notification centers

🤖 Generated with [Claude Code](https://claude.com/claude-code)